### PR TITLE
Added a Regex Definition for Saudi Arabian Passports

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -141,6 +141,16 @@
          "<<<<"
       ]
    },
+   "Saudi Arabian Passport": {
+      "regex":"(?:P<SAU)(?:[A-Z0-9<].+)",
+      "region":"Saudi Arabia",
+      "keywords":[
+         "Passport",
+         "Saudi Arabia",
+         "SAU",
+         "<<<<"
+      ]
+   },
    "Nebraska Driver's License": {
       "regex":"[A-Z]{1}[0-9]{9,11}",
       "region":"United States",


### PR DESCRIPTION
Added a simple JSON definition for Saudi Arabian passports and validated against 5 live passports. 

Interestingly, although not ideal, the keyword "SAU" must be included as the alternative phrase "Kingdom of Saudi Arabia" or "Saudi Arabia" is not reliable enough because of the location/design of the phrase (the phrase is located at the very top of the passport and the font type/colour is inverted/different so isn't always picked up).

Hopefully on the long run an easier keyword to match is specific Arabic words, but for the time being "SAU" is the temporary solution with ideally little false positives.